### PR TITLE
Kubefedcluster add support for specifying TLS verification (ignore All, SubjectName, ValidityPeriod)

### DIFF
--- a/pkg/apis/core/v1beta1/kubefedcluster_types.go
+++ b/pkg/apis/core/v1beta1/kubefedcluster_types.go
@@ -23,6 +23,14 @@ import (
 	"sigs.k8s.io/kubefed/pkg/apis/core/common"
 )
 
+type TLSValidation string
+
+const (
+	All            TLSValidation = "*"
+	SubjectName    TLSValidation = "SubjectName"
+	ValidityPeriod TLSValidation = "ValidityPeriod"
+)
+
 // KubeFedClusterSpec defines the desired state of KubeFedCluster
 type KubeFedClusterSpec struct {
 	// The API endpoint of the member cluster. This can be a hostname,
@@ -37,6 +45,12 @@ type KubeFedClusterSpec struct {
 	// member cluster. The secret needs to exist in the same namespace
 	// as the control plane and should have a "token" key.
 	SecretRef LocalSecretReference `json:"secretRef"`
+
+	// DisabledTLSValidations defines a list of checks to ignore when validating
+	// the TLS connection to the member cluster.  This can be any of *, SubjectName, or ValidityPeriod.
+	// If * is specified, it is expected to be the only option in list.
+	// +optional
+	DisabledTLSValidations []TLSValidation `json:"disabledTLSValidations,omitempty"`
 }
 
 // LocalSecretReference is a reference to a secret within the enclosing

--- a/pkg/apis/core/v1beta1/validation/validation.go
+++ b/pkg/apis/core/v1beta1/validation/validation.go
@@ -268,6 +268,18 @@ func validateGreaterThan0(path *field.Path, value int64) field.ErrorList {
 }
 
 func ValidateKubeFedCluster(object *v1beta1.KubeFedCluster) field.ErrorList {
+	spec := object.Spec
+	specPath := field.NewPath("spec")
 	allErrs := field.ErrorList{}
+
+	disabledTLSValidationsPath := specPath.Child("disabledTLSValidations")
+	for i, value := range spec.DisabledTLSValidations {
+		if i > 0 && value == v1beta1.All {
+			allErrs = append(allErrs, field.Invalid(disabledTLSValidationsPath, value, "must be the value specified when skipping all TLS validations"))
+		}
+		allErrs = append(allErrs, validateEnumStrings(disabledTLSValidationsPath, string(value),
+			[]string{string(v1beta1.All), string(v1beta1.SubjectName), string(v1beta1.ValidityPeriod)})...)
+	}
+
 	return allErrs
 }

--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -18,6 +18,12 @@ package util
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/pkg/errors"
@@ -26,6 +32,8 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/transport"
+	"k8s.io/klog"
 
 	fedv1b1 "sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/kubefed/pkg/client/generic"
@@ -89,6 +97,13 @@ func BuildClusterConfig(fedCluster *fedv1b1.KubeFedCluster, client generic.Clien
 	clusterConfig.QPS = KubeAPIQPS
 	clusterConfig.Burst = KubeAPIBurst
 
+	if len(fedCluster.Spec.DisabledTLSValidations) != 0 {
+		klog.V(1).Infof("Cluster %s will use a custom transport for TLS certificate validation", fedCluster.Name)
+		if err = CustomizeTLSTransport(fedCluster, clusterConfig); err != nil {
+			return nil, err
+		}
+	}
+
 	return clusterConfig, nil
 }
 
@@ -100,4 +115,120 @@ func IsPrimaryCluster(obj, clusterObj pkgruntime.Object) bool {
 	meta := MetaAccessor(obj)
 	clusterMeta := MetaAccessor(clusterObj)
 	return meta.GetUID() == clusterMeta.GetUID()
+}
+
+// CustomizeTLSTransport replaces the restclient.Config.Transport with one that
+// implements the desired TLS certificate validations
+func CustomizeTLSTransport(fedCluster *fedv1b1.KubeFedCluster, clientConfig *restclient.Config) error {
+	clientTransportConfig, err := clientConfig.TransportConfig()
+	if err != nil {
+		return fmt.Errorf("Cluster %s client transport config error: %s", fedCluster.Name, err)
+	}
+	transportConfig, err := transport.TLSConfigFor(clientTransportConfig)
+	if err != nil {
+		return fmt.Errorf("Cluster %s transport error: %s", fedCluster.Name, err)
+	}
+
+	err = CustomizeCertificateValidation(fedCluster, transportConfig)
+	if err != nil {
+		return fmt.Errorf("Cluster %s custom certificate validation error: %s", fedCluster.Name, err)
+	}
+
+	// using the same defaults as http.DefaultTransport
+	clientConfig.Transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       transportConfig,
+	}
+	clientConfig.TLSClientConfig = restclient.TLSClientConfig{}
+	return nil
+}
+
+// CustomizeCertificateValidation modifies an existing tls.Config to disable the
+// desired TLS checks in KubeFedCluster config
+func CustomizeCertificateValidation(fedCluster *fedv1b1.KubeFedCluster, tlsConfig *tls.Config) error {
+	// InsecureSkipVerify must be enabled to prevent early validation errors from
+	// returning before VerifyPeerCertificate is run
+	tlsConfig.InsecureSkipVerify = true
+
+	var ignoreSubjectName, ignoreValidityPeriod bool
+	for _, validation := range fedCluster.Spec.DisabledTLSValidations {
+		switch fedv1b1.TLSValidation(validation) {
+		case fedv1b1.All:
+			klog.V(1).Infof("Cluster %s will not perform TLS certificate validation", fedCluster.Name)
+			return nil
+		case fedv1b1.SubjectName:
+			ignoreSubjectName = true
+		case fedv1b1.ValidityPeriod:
+			ignoreValidityPeriod = true
+		}
+	}
+
+	// Normal TLS SubjectName validation uses the conn dnsname for validation,
+	// but this is not available when using a VerifyPeerCertificate functions.
+	// As a workaround, we will fill the tls.Config.ServerName with the URL host
+	// specified as the KubeFedCluster API target
+	if !ignoreSubjectName && tlsConfig.ServerName == "" {
+		apiURL, err := url.Parse(fedCluster.Spec.APIEndpoint)
+		if err != nil {
+			return fmt.Errorf("failed to identify a valid host from APIEndpoint for use in SubjectName validation")
+		}
+		tlsConfig.ServerName = apiURL.Hostname()
+	}
+
+	// VerifyPeerCertificate uses the same logic as crypto/tls Conn.verifyServerCertificate
+	// but uses a modified set of options to ignore specific validations
+	tlsConfig.VerifyPeerCertificate = func(certificates [][]byte, verifiedChains [][]*x509.Certificate) error {
+		opts := x509.VerifyOptions{
+			Roots:         tlsConfig.RootCAs,
+			CurrentTime:   time.Now(),
+			Intermediates: x509.NewCertPool(),
+			DNSName:       tlsConfig.ServerName,
+		}
+		if tlsConfig.Time != nil {
+			opts.CurrentTime = tlsConfig.Time()
+		}
+
+		certs := make([]*x509.Certificate, len(certificates))
+		for i, asn1Data := range certificates {
+			cert, err := x509.ParseCertificate(asn1Data)
+			if err != nil {
+				return errors.New("tls: failed to parse certificate from server: " + err.Error())
+			}
+			certs[i] = cert
+		}
+
+		for i, cert := range certs {
+			if i == 0 {
+				continue
+			}
+			opts.Intermediates.AddCert(cert)
+		}
+
+		if ignoreSubjectName {
+			// set the DNSName to nil to ignore the name validation
+			opts.DNSName = ""
+			klog.V(1).Infof("Cluster %s will not perform tls certificate SubjectName validation", fedCluster.Name)
+		}
+		if ignoreValidityPeriod {
+			// set the CurrentTime to immediately after the certificate start time
+			// this will ensure that certificate passes the validity period check
+			opts.CurrentTime = certs[0].NotBefore.Add(time.Second)
+			klog.V(1).Infof("Cluster %s will not perform tls certificate ValidityPeriod validation", fedCluster.Name)
+		}
+
+		_, err := certs[0].Verify(opts)
+
+		return err
+	}
+
+	return nil
 }

--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -247,8 +247,13 @@ func JoinCluster(hostConfig, clusterConfig *rest.Config, kubefedNamespace,
 
 	klog.V(2).Info("Creating federated cluster resource")
 
+	var disabledTLSValidations []fedv1b1.TLSValidation
+	if clusterConfig.TLSClientConfig.Insecure {
+		disabledTLSValidations = append(disabledTLSValidations, fedv1b1.All)
+	}
+
 	_, err = createKubeFedCluster(client, joiningClusterName, clusterConfig.Host,
-		secret.Name, kubefedNamespace, caBundle, dryRun, errorOnExisting)
+		secret.Name, kubefedNamespace, caBundle, disabledTLSValidations, dryRun, errorOnExisting)
 	if err != nil {
 		klog.V(2).Infof("Failed to create federated cluster resource: %v", err)
 		return err
@@ -283,7 +288,8 @@ func performPreflightChecks(clusterClientset kubeclient.Interface, name, hostClu
 // createKubeFedCluster creates a federated cluster resource that associates
 // the cluster and secret.
 func createKubeFedCluster(client genericclient.Client, joiningClusterName, apiEndpoint,
-	secretName, kubefedNamespace string, caBundle []byte, dryRun, errorOnExisting bool) (*fedv1b1.KubeFedCluster, error) {
+	secretName, kubefedNamespace string, caBundle []byte, disabledTLSValidations []fedv1b1.TLSValidation,
+	dryRun, errorOnExisting bool) (*fedv1b1.KubeFedCluster, error) {
 	fedCluster := &fedv1b1.KubeFedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: kubefedNamespace,
@@ -295,6 +301,7 @@ func createKubeFedCluster(client genericclient.Client, joiningClusterName, apiEn
 			SecretRef: fedv1b1.LocalSecretReference{
 				Name: secretName,
 			},
+			DisabledTLSValidations: disabledTLSValidations,
 		},
 	}
 


### PR DESCRIPTION
Implements an optional field in v1beta1/KubeFedCluster to specify which TLS checks to ignore.  Disabling TLS checks is implemented by setting tls.Config.InsecureSkipVerify  and providing a function closure implementing tls.Config.VerifyPeerCertificate (to selectively ignore SubjectName or ValidityPeriod).

Modifies kubefedctl join to preserve the kubeconfig cluster setting of InsecureSkipTLSVerify by setting the new field in v1beta1/KubeFedCluster.